### PR TITLE
Refactor Triggers PKCE parser on grant_type `code` only

### DIFF
--- a/lib/request/extensions.js
+++ b/lib/request/extensions.js
@@ -32,7 +32,7 @@ module.exports = function() {
   }
   
   var mod = {};
-  mod.name = '*';
+  mod.name = 'code';
   mod.request = request;
   return mod;
 }


### PR DESCRIPTION
Currently the PKCE extension runs on every grant_type.
With the change the request parser only triggers on grant_type `code`.

Reason: It is unneccessary that it runs on implicit flow.

- [x ] I have read the [CONTRIBUTING](https://github.com/jaredhanson/oauth2orize-pkce/blob/master/CONTRIBUTING.md) guidelines.
- [ ] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [ ] The automated test suite (`$ make test`) executes successfully.
- [ ] The automated code linting (`$ make lint`) executes successfully.
